### PR TITLE
Copy more model content

### DIFF
--- a/cellml1to2.xsl
+++ b/cellml1to2.xsl
@@ -87,6 +87,10 @@
 		</xsl:if>
 	</xsl:template>
 
+	<!-- The reaction element has been removed -->
+	<xsl:template match="cellml10:reaction | cellml11:reaction">
+	</xsl:template>
+
 	<!-- The cmeta:id attribute becomes an unprefixed attribute on CellML elements -->
 	<xsl:template match="cellml10:*/@cmeta:id | cellml11:*/@cmeta:id">
 		<xsl:attribute name="id">
@@ -97,6 +101,11 @@
 	<!-- The xlink:href attribute gets copied -->
 	<xsl:template match="@xlink:href">
 		<xsl:copy-of select="."/>
+	</xsl:template>
+
+	<!-- Comments & text should be copied -->
+	<xsl:template match="comment() | text()">
+		<xsl:copy/>
 	</xsl:template>
 
 </xsl:stylesheet>

--- a/cellml1to2.xsl
+++ b/cellml1to2.xsl
@@ -1,104 +1,102 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:mathml="http://www.w3.org/1998/Math/MathML"
 	xmlns:cellml10="http://www.cellml.org/cellml/1.0#"
-	xmlns:cellml11="http://www.cellml.org/cellml/1.1#" 
+	xmlns:cellml11="http://www.cellml.org/cellml/1.1#"
 	xmlns:cmeta="http://www.cellml.org/metadata/1.0#"
-	xmlns:cellml2="http://www.cellml.org/cellml/2.0#">
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	xmlns:cellml="http://www.cellml.org/cellml/2.0#"
+	exclude-result-prefixes="cmeta cellml10 cellml11 mathml">
 
-	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
-	
-	<xsl:template match="/cellml10:model | /cellml11:model">
-		<xsl:element name="model" namespace="http://www.cellml.org/cellml/2.0#">
-			<xsl:apply-templates select="@name | @cmeta:id" />
-			<xsl:apply-templates select="*" />
+	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="no"/>
+
+	<!-- Any elements or attributes not specified below will be dropped -->
+	<xsl:template match="* | @*" priority="-1.0">
+	</xsl:template>
+
+	<!-- MathML gets copied over as-is -->
+	<xsl:template match="mathml:*">
+		<xsl:copy copy-namespaces="no">
+			<xsl:apply-templates select="@* | node()"/>
+		</xsl:copy>
+	</xsl:template>
+
+	<!-- By default attributes on MathML elements are also copied.
+		Note that the priority attribute ensures the subsequent template takes priority over this one. -->
+	<xsl:template match="mathml:*/@*" priority="-0.5">
+		<xsl:copy-of select="."/>
+	</xsl:template>
+
+	<!-- Except for cellml:units attributes, which need to change namespace -->
+	<xsl:template match="@cellml10:units | @cellml11:units">
+		<xsl:attribute name="units" namespace="http://www.cellml.org/cellml/2.0#">
+			<xsl:value-of select="."/>
+		</xsl:attribute>
+	</xsl:template>
+
+	<!-- CellML elements get changed to the latest namespace but otherwise left the same by default.
+		Alternative handling for specific elements is given below. -->
+	<xsl:template match="cellml10:* | cellml11:*">
+		<xsl:element name="{local-name()}" namespace="http://www.cellml.org/cellml/2.0#">
+			<!-- Explicit copy of unprefixed attributes that can appear in CellML elements -->
+			<xsl:copy-of select="
+					@name | @initial_value |
+					@base_units | @units | @prefix | @exponent | @multiplier | @offset |
+					@units_ref | @component_ref | @component |
+					@component_1 | @component_2 | @variable_1 | @variable_2"/>
+			<xsl:apply-templates select="@* | node()"/>
 		</xsl:element>
 	</xsl:template>
 
-	<xsl:template match="cellml10:component | cellml11:component">
-		<xsl:element name="component" namespace="http://www.cellml.org/cellml/2.0#">
-			<xsl:apply-templates select="@name | @cmeta:id" />
-			<xsl:apply-templates select="*" />
-		</xsl:element>
+	<!-- We treat the root element specially so the cellml prefix gets declared globally in the result document -->
+	<xsl:template match="cellml10:model | cellml11:model">
+		<model xmlns="http://www.cellml.org/cellml/2.0#" xmlns:cellml="http://www.cellml.org/cellml/2.0#">
+			<xsl:copy-of select="@name"/>
+			<xsl:apply-templates select="@* | node()"/>
+		</model>
 	</xsl:template>
 
+	<!-- Variable elements need special handling for their interface attributes -->
 	<xsl:template match="cellml10:variable | cellml11:variable">
 		<xsl:element name="variable" namespace="http://www.cellml.org/cellml/2.0#">
-			<xsl:apply-templates select="@name | @cmeta:id" />
+			<xsl:apply-templates select="@cmeta:id"/>
+			<xsl:copy-of select="@name | @initial_value"/>
+			<xsl:variable name="has_public_if" select="@public_interface and @public_interface != 'none'"/>
+			<xsl:variable name="has_private_if" select="@private_interface and @private_interface != 'none'"/>
 			<xsl:choose>
-				<xsl:when test="@private_interface and @public_interface">
-					<xsl:choose>
-						<xsl:when test="@private_interface='none' and @public_interface='none'">
-							<xsl:attribute name="interface">none</xsl:attribute>
-						</xsl:when>
-						<xsl:when test="@private_interface='none'">
-							<xsl:attribute name="interface">public</xsl:attribute>
-						</xsl:when>
-						<xsl:when test="@public_interface='none'">
-							<xsl:attribute name="interface">private</xsl:attribute>
-						</xsl:when>
-						<xsl:otherwise>
-							<xsl:attribute name="interface">public_and_private</xsl:attribute>
-						</xsl:otherwise>
-					</xsl:choose>
+				<xsl:when test="$has_public_if and $has_private_if">
+					<xsl:attribute name="interface">public_and_private</xsl:attribute>
 				</xsl:when>
-				<xsl:when test="@private_interface">
-					<xsl:choose>
-						<xsl:when test="@private_interface='none'">
-							<xsl:attribute name="interface">none</xsl:attribute>
-						</xsl:when>
-						<xsl:otherwise>
-							<xsl:attribute name="interface">private</xsl:attribute>
-						</xsl:otherwise>
-					</xsl:choose>
+				<xsl:when test="$has_public_if">
+					<xsl:attribute name="interface">public</xsl:attribute>
 				</xsl:when>
-				<xsl:when test="@public_interface">
-					<xsl:choose>
-						<xsl:when test="@public_interface='none'">
-							<xsl:attribute name="interface">none</xsl:attribute>
-						</xsl:when>
-						<xsl:otherwise>
-							<xsl:attribute name="interface">public</xsl:attribute>
-						</xsl:otherwise>
-					</xsl:choose>
+				<xsl:when test="$has_private_if">
+					<xsl:attribute name="interface">private</xsl:attribute>
 				</xsl:when>
 			</xsl:choose>
 		</xsl:element>
 	</xsl:template>
-	
+
+	<!-- Only the encapsulation relationship exists for CellML 2.0 -->
 	<xsl:template match="cellml10:group | cellml11:group">
-		<xsl:if test="./cellml10:relationship_ref[@relationship='encapsulation'] | ./cellml11:relationship_ref[@relationship='encapsulation']">
+		<xsl:if test="cellml10:relationship_ref[@relationship = 'encapsulation'] | cellml11:relationship_ref[@relationship = 'encapsulation']">
 			<xsl:element name="encapsulation" namespace="http://www.cellml.org/cellml/2.0#">
-				<xsl:apply-templates select="@cmeta:id" />
-				<xsl:apply-templates select="*"/>
+				<xsl:apply-templates select="@cmeta:id"/>
+				<xsl:apply-templates select="cellml10:component_ref | cellml11:component_ref | text()"/>
 			</xsl:element>
 		</xsl:if>
 	</xsl:template>
-	
-	<xsl:template match="cellml10:component_ref | cellml11:component_ref">
-		<xsl:element name="component_ref" namespace="http://www.cellml.org/cellml/2.0#">
-			<xsl:apply-templates select="@cmeta:id" />
-			<xsl:attribute name="component">
-				<xsl:value-of select="@component"/>
-			</xsl:attribute>
-			<xsl:apply-templates select="*"/>
-		</xsl:element>
-	</xsl:template>
 
-	<xsl:template match="@name">
-		<xsl:attribute name="name">
-			<xsl:value-of select="." />
-  		</xsl:attribute>
-	</xsl:template>
-	
-	<xsl:template match="@cmeta:id">
+	<!-- The cmeta:id attribute becomes an unprefixed attribute on CellML elements -->
+	<xsl:template match="cellml10:*/@cmeta:id | cellml11:*/@cmeta:id">
 		<xsl:attribute name="id">
-  			<xsl:value-of select="." />
-  		</xsl:attribute>
+			<xsl:value-of select="."/>
+		</xsl:attribute>
 	</xsl:template>
 
-
-	<xsl:template match="*">
-		<!-- don't do anything with elements we don't know -->
+	<!-- The xlink:href attribute gets copied -->
+	<xsl:template match="@xlink:href">
+		<xsl:copy-of select="."/>
 	</xsl:template>
+
 </xsl:stylesheet>

--- a/test-models/cellml1.0.xml
+++ b/test-models/cellml1.0.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="../cellml1to2.xsl"?>
 <model xmlns="http://www.cellml.org/cellml/1.0#" xmlns:cellml="http://www.cellml.org/cellml/1.1#" xmlns:cmeta="http://www.cellml.org/metadata/1.0#" cmeta:id="sin_approximations_import" name="sin_approximations_import">
+  <units name="mV_per_ms">
+    <unit units="volt" prefix="milli"/>
+    <unit units="second" prefix="milli" exponent="-1"/>
+  </units>
+  <units name="pH" base_units="yes"/>
+  <units name="fahrenheit">
+    <unit multiplier="1.8" units="celsius" offset="32.0"/>
+  </units>
   <component cmeta:id="main" name="main">
     <variable cmeta:id="x" initial_value="0" name="x" private_interface="out" public_interface="out" units="dimensionless"/>
     <variable cmeta:id="sin" name="sin1" private_interface="in" public_interface="out" units="dimensionless"/>

--- a/test-models/cellml1.0.xml
+++ b/test-models/cellml1.0.xml
@@ -44,6 +44,25 @@
     <variable name="test_private_public_interface_none" units="dimensionless" private_interface="none" public_interface="none"/>
     <variable name="test_private_none_public_in" units="dimensionless" private_interface="none" public_interface="in"/>
     <variable name="test_private_out_public_none" units="dimensionless" private_interface="out" public_interface="none"/>
+    <!-- Note that this comment SHOULD be copied, but the reaction SHOULD NOT -->
+    <reaction reversible="yes">
+      <variable_ref variable="test_no_interface">
+        <role role="reactant" direction="forward" delta_variable="test_public_interface_in" stoichiometry="1"/>
+      </variable_ref>
+      <variable_ref variable="test_public_interface_out">
+        <role role="product" direction="forward" delta_variable="test_public_interface_out" stoichiometry="2"/>
+      </variable_ref>
+      <variable_ref variable="test_private_none_public_in">
+        <role role="rate">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply id="reaction_rate"><eq/>
+              <ci>test_private_none_public_in</ci>
+              <ci>test_private_interface_none</ci>
+            </apply>
+          </math>
+        </role>
+      </variable_ref>
+    </reaction>
   </component>
   <group cmeta:id="groupId">
   	<relationship_ref relationship="encapsulation"/>

--- a/test-models/cellml1.0.xml
+++ b/test-models/cellml1.0.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="../cellml1to2.xsl"?>
 <model xmlns="http://www.cellml.org/cellml/1.0#" xmlns:cellml="http://www.cellml.org/cellml/1.1#" xmlns:cmeta="http://www.cellml.org/metadata/1.0#" cmeta:id="sin_approximations_import" name="sin_approximations_import">
   <component cmeta:id="main" name="main">
     <variable cmeta:id="x" initial_value="0" name="x" private_interface="out" public_interface="out" units="dimensionless"/>

--- a/test-models/cellml1.0.xml
+++ b/test-models/cellml1.0.xml
@@ -54,4 +54,9 @@
   		</component_ref>
   	</component_ref>
   </group>
+  <connection>
+    <map_components component_1="main" component_2="actual_sin"/>
+    <map_variables variable_1="sin" variable_2="sin"/>
+    <map_variables variable_1="x" variable_2="x"/>
+  </connection>
 </model>

--- a/test-models/cellml1.1.xml
+++ b/test-models/cellml1.1.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="../cellml1to2.xsl"?>
 <model xmlns="http://www.cellml.org/cellml/1.1#" xmlns:cellml="http://www.cellml.org/cellml/1.1#" xmlns:cmeta="http://www.cellml.org/metadata/1.0#" cmeta:id="sin_approximations_import" name="sin_approximations_import">
+  <units name="mV_per_ms">
+    <unit units="volt" prefix="milli"/>
+    <unit units="second" prefix="milli" exponent="-1"/>
+  </units>
+  <units name="pH" base_units="yes"/>
+  <units name="fahrenheit">
+    <unit multiplier="1.8" units="celsius" offset="32.0"/>
+  </units>
   <component cmeta:id="main" name="main">
     <variable cmeta:id="x" initial_value="0" name="x" private_interface="out" public_interface="out" units="dimensionless"/>
     <variable cmeta:id="sin" name="sin1" private_interface="in" public_interface="out" units="dimensionless"/>

--- a/test-models/cellml1.1.xml
+++ b/test-models/cellml1.1.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="../cellml1to2.xsl"?>
-<model xmlns="http://www.cellml.org/cellml/1.1#" xmlns:cellml="http://www.cellml.org/cellml/1.1#" xmlns:cmeta="http://www.cellml.org/metadata/1.0#" cmeta:id="sin_approximations_import" name="sin_approximations_import">
+<model xmlns="http://www.cellml.org/cellml/1.1#" xmlns:cellml="http://www.cellml.org/cellml/1.1#"
+       xmlns:cmeta="http://www.cellml.org/metadata/1.0#"
+       xmlns:xlink="http://www.w3.org/1999/xlink"
+       cmeta:id="sin_approximations_import" name="sin_approximations_import">
   <units name="mV_per_ms">
     <unit units="volt" prefix="milli"/>
     <unit units="second" prefix="milli" exponent="-1"/>
@@ -9,6 +12,10 @@
   <units name="fahrenheit">
     <unit multiplier="1.8" units="celsius" offset="32.0"/>
   </units>
+  <import xlink:href="importee.xml">
+    <units name="millivolts" units_ref="millivolts"/>
+    <component name="imported_comp" component_ref="main_comp"/>
+  </import>
   <component cmeta:id="main" name="main">
     <variable cmeta:id="x" initial_value="0" name="x" private_interface="out" public_interface="out" units="dimensionless"/>
     <variable cmeta:id="sin" name="sin1" private_interface="in" public_interface="out" units="dimensionless"/>
@@ -54,4 +61,13 @@
   		</component_ref>
   	</component_ref>
   </group>
+  <connection>
+    <map_components component_1="main" component_2="actual_sin"/>
+    <map_variables variable_1="sin" variable_2="sin"/>
+    <map_variables variable_1="x" variable_2="x"/>
+  </connection>
+  <connection>
+    <map_components component_1="main" component_2="imported_comp"/>
+    <map_variables variable_1="sin2" variable_2="input"/>
+  </connection>
 </model>

--- a/test-models/cellml1.1.xml
+++ b/test-models/cellml1.1.xml
@@ -51,6 +51,25 @@
     <variable name="test_private_public_interface_none" units="dimensionless" private_interface="none" public_interface="none"/>
     <variable name="test_private_none_public_in" units="dimensionless" private_interface="none" public_interface="in"/>
     <variable name="test_private_out_public_none" units="dimensionless" private_interface="out" public_interface="none"/>
+    <!-- Note that this comment SHOULD be copied, but the reaction SHOULD NOT -->
+    <reaction reversible="yes">
+      <variable_ref variable="test_no_interface">
+        <role role="reactant" direction="forward" delta_variable="test_public_interface_in" stoichiometry="1"/>
+      </variable_ref>
+      <variable_ref variable="test_public_interface_out">
+        <role role="product" direction="forward" delta_variable="test_public_interface_out" stoichiometry="2"/>
+      </variable_ref>
+      <variable_ref variable="test_private_none_public_in">
+        <role role="rate">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply id="reaction_rate"><eq/>
+              <ci>test_private_none_public_in</ci>
+              <ci>test_private_interface_none</ci>
+            </apply>
+          </math>
+        </role>
+      </variable_ref>
+    </reaction>
   </component>
   <group cmeta:id="groupId">
   	<relationship_ref relationship="encapsulation"/>

--- a/test-models/cellml1.1.xml
+++ b/test-models/cellml1.1.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="../cellml1to2.xsl"?>
 <model xmlns="http://www.cellml.org/cellml/1.1#" xmlns:cellml="http://www.cellml.org/cellml/1.1#" xmlns:cmeta="http://www.cellml.org/metadata/1.0#" cmeta:id="sin_approximations_import" name="sin_approximations_import">
   <component cmeta:id="main" name="main">
     <variable cmeta:id="x" initial_value="0" name="x" private_interface="out" public_interface="out" units="dimensionless"/>


### PR DESCRIPTION
This version now copies everything we want I think.  It should ignore RDF, although I haven't tested that.  It probably doesn't ignore reactions; I'll add an extra commit for that shortly.

Note that it needs an XSLT 2 processor to handle namespace nodes nicely. Tested using the Saxon engine within oXygen XML.
