### PR TITLE
Handle the map from CellML 1.0,1.1 connections

### DIFF
--- a/cellml1to2.xsl
+++ b/cellml1to2.xsl
@@ -8,7 +8,7 @@
 	xmlns:cellml="http://www.cellml.org/cellml/2.0#"
 	exclude-result-prefixes="cmeta cellml10 cellml11 mathml">
 
-	<xsl:output method="xml" version="2.0" encoding="UTF-8" indent="no"/>
+	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="no"/>
 
 	<!-- Any elements or attributes not specified below will be dropped -->
 	<xsl:template match="* | @*" priority="-1.0">
@@ -43,7 +43,7 @@
 					@name | @units | @initial_value |
 					@prefix | @exponent | @multiplier |
 					@units_ref | @component_ref | @component |
-					@component_1 | @component_2 | @variable_1 | @variable_2 | @id"/>
+					@component_1 | @component_2 | @variable_1 | @variable_2"/>
 			<xsl:apply-templates select="@* | node()"/>
 		</xsl:element>
 	</xsl:template>

--- a/cellml1to2.xsl
+++ b/cellml1to2.xsl
@@ -8,7 +8,7 @@
 	xmlns:cellml="http://www.cellml.org/cellml/2.0#"
 	exclude-result-prefixes="cmeta cellml10 cellml11 mathml">
 
-	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="no"/>
+	<xsl:output method="xml" version="2.0" encoding="UTF-8" indent="no"/>
 
 	<!-- Any elements or attributes not specified below will be dropped -->
 	<xsl:template match="* | @*" priority="-1.0">
@@ -40,10 +40,10 @@
 		<xsl:element name="{local-name()}" namespace="http://www.cellml.org/cellml/2.0#">
 			<!-- Explicit copy of unprefixed attributes that can appear in CellML elements -->
 			<xsl:copy-of select="
-					@name | @initial_value |
-					@base_units | @units | @prefix | @exponent | @multiplier | @offset |
+					@name | @units | @initial_value |
+					@prefix | @exponent | @multiplier |
 					@units_ref | @component_ref | @component |
-					@component_1 | @component_2 | @variable_1 | @variable_2"/>
+					@component_1 | @component_2 | @variable_1 | @variable_2 | @id"/>
 			<xsl:apply-templates select="@* | node()"/>
 		</xsl:element>
 	</xsl:template>
@@ -91,6 +91,19 @@
 	<xsl:template match="cellml10:reaction | cellml11:reaction">
 	</xsl:template>
 
+	<!-- The connection element should be copied -->
+	<xsl:template match="cellml10:connection | cellml11:connection">
+		<xsl:element name="connection" namespace="http://www.cellml.org/cellml/2.0#">
+			<xsl:copy-of select="@*|cellml10:map_components/@*" />
+			<xsl:copy-of select="@*|cellml11:map_components/@*" />
+			<xsl:apply-templates />
+		</xsl:element>
+	</xsl:template>
+
+	<!-- The map_components element should be ignored -->
+	<xsl:template match="cellml10:map_components | cellml11:map_components">
+	</xsl:template>
+
 	<!-- The cmeta:id attribute becomes an unprefixed attribute on CellML elements -->
 	<xsl:template match="cellml10:*/@cmeta:id | cellml11:*/@cmeta:id">
 		<xsl:attribute name="id">
@@ -109,3 +122,4 @@
 	</xsl:template>
 
 </xsl:stylesheet>
+


### PR DESCRIPTION
Connections have changed a little in CellML 2.0.  These changes map from CellML 1.0, 1.1 to CellML 2.0.