### PR TITLE
Fix to stop every cn from redefining the CellML 2.0 namespace.

### DIFF
--- a/cellml1to2.xsl
+++ b/cellml1to2.xsl
@@ -29,7 +29,8 @@
 
 	<!-- Except for cellml:units attributes, which need to change namespace -->
 	<xsl:template match="@cellml10:units | @cellml11:units">
-		<xsl:attribute name="units" namespace="http://www.cellml.org/cellml/2.0#">
+		<xsl:attribute name="cellml:units">
+            <xsl:namespace name="cellml" select="http://www.cellml.org/cellml/1.1#" />
 			<xsl:value-of select="."/>
 		</xsl:attribute>
 	</xsl:template>

--- a/cellml1to2.xsl
+++ b/cellml1to2.xsl
@@ -29,7 +29,7 @@
 
 	<!-- Except for cellml:units attributes, which need to change namespace -->
 	<xsl:template match="@cellml10:units | @cellml11:units">
-		<xsl:attribute name="cellml:units">
+		<xsl:attribute name="cellml:units" namespace="http://www.cellml.org/cellml/2.0#">
 			<xsl:namespace name="cellml" select="http://www.cellml.org/cellml/2.0#" />
 			<xsl:value-of select="."/>
 		</xsl:attribute>

--- a/cellml1to2.xsl
+++ b/cellml1to2.xsl
@@ -30,7 +30,7 @@
 	<!-- Except for cellml:units attributes, which need to change namespace -->
 	<xsl:template match="@cellml10:units | @cellml11:units">
 		<xsl:attribute name="cellml:units">
-            <xsl:namespace name="cellml" select="http://www.cellml.org/cellml/2.0#" />
+			<xsl:namespace name="cellml" select="http://www.cellml.org/cellml/2.0#" />
 			<xsl:value-of select="."/>
 		</xsl:attribute>
 	</xsl:template>

--- a/cellml1to2.xsl
+++ b/cellml1to2.xsl
@@ -30,7 +30,7 @@
 	<!-- Except for cellml:units attributes, which need to change namespace -->
 	<xsl:template match="@cellml10:units | @cellml11:units">
 		<xsl:attribute name="cellml:units">
-            <xsl:namespace name="cellml" select="http://www.cellml.org/cellml/1.1#" />
+            <xsl:namespace name="cellml" select="http://www.cellml.org/cellml/2.0#" />
 			<xsl:value-of select="."/>
 		</xsl:attribute>
 	</xsl:template>


### PR DESCRIPTION
Old output (using [lxml](https://lxml.de/xpathxslt.html#xslt))

```
      <math xmlns="http://www.w3.org/1998/Math/MathML">
         <apply>
            <eq/>
            <ci>vcell</ci>
            <apply>
               <times/>
               <cn xmlns:ns_1="http://www.cellml.org/cellml/1.1#" ns_1:units="m2u">1000</cn>
               <pi/>
               <ci>a</ci>
```

New output

```
      <math xmlns="http://www.w3.org/1998/Math/MathML">
         <apply>
            <eq/>
            <ci>vcell</ci>
            <apply>
               <times/>
               <cn cellml:units="m2u">1000</cn>
               <pi/>
               <ci>a</ci>
```

I don't know _why_ this fix works, but it seems to.
Maybe @jonc125 knows?