### PR TITLE
Remove xsl:namespace from cellml:units matching

### DIFF
--- a/cellml1to2.xsl
+++ b/cellml1to2.xsl
@@ -30,7 +30,6 @@
 	<!-- Except for cellml:units attributes, which need to change namespace -->
 	<xsl:template match="@cellml10:units | @cellml11:units">
 		<xsl:attribute name="cellml:units" namespace="http://www.cellml.org/cellml/2.0#">
-			<xsl:namespace name="cellml" select="http://www.cellml.org/cellml/2.0#" />
 			<xsl:value-of select="."/>
 		</xsl:attribute>
 	</xsl:template>


### PR DESCRIPTION
When I use `Saxon-HE 10.5J` I have to remove this line for the transform to work. 